### PR TITLE
Missing require dependencies?

### DIFF
--- a/lib/markdown_prawn.rb
+++ b/lib/markdown_prawn.rb
@@ -1,6 +1,10 @@
 #!/usr/bin/env ruby
 require 'rubygems'
 require 'prawn'
+require 'active_support'
+require 'active_support/core_ext/object'
+require 'strscan'
+
 module MarkdownPrawn
   # Namespace for PDF Fun
 end

--- a/markdown_prawn.gemspec
+++ b/markdown_prawn.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.email = "dvboom@hotmail.com"
   spec.rubyforge_project = "markdown_prawn"
   spec.add_dependency('prawn')
+  spec.add_dependency('activesupport')
   spec.homepage = "http://github.com/vanboom"
   spec.summary = description
   spec.description = description


### PR DESCRIPTION
My environment required that I added a few dependencies to markdown_prawn to make it work, including the standalone tool.
I'm not sure if your environment already has these requirements, or if it's something specific to Ruby 2.2 on Mac OS, but these seem to be required.

I'm also not actually sure if the gemspec is correct with this modification.